### PR TITLE
change pop and unshift to index references to preserve all of the lin…

### DIFF
--- a/lib/vcard.js
+++ b/lib/vcard.js
@@ -151,23 +151,25 @@ vCard.prototype = {
     // Keep begin and end markers
     // for eventual error messages
     var begin, version, end, line
-    
+
+
+    // the following if statements have been changed to lines[index] instead of .shift() and .pop() because those two methods change the array in place instead of just checking the first and last indexes. The result preserves all of the lines instead of risking deleting the first and the last two.
     // Check for begin marker
-    if( begin = lines.shift() && /BEGIN:VCARD/i.test( begin ) ) {
+    if( begin = lines[0] && /BEGIN:VCARD/i.test( begin ) ) {
       throw new SyntaxError(
         'Invalid format: expected "BEGIN:VCARD" but found "'+ begin +'"'
       )
     }
     
     // Check for the end marker
-    if( end = lines.pop() && /END:VCARD/i.test( end ) ) {
+    if( end = lines[lines.length-1] && /END:VCARD/i.test( end ) ) {
       throw new SyntaxError(
         'Invalid format: expected "END:VCARD" but found "'+ end +'"'
       )
     }
     
     // Check for version number
-    if( version = lines.pop() && /VERSION:\d\.\d/i.test( version ) ) {
+    if( version = lines[lines.length-1] && /VERSION:\d\.\d/i.test( version ) ) {
       throw new SyntaxError(
         'Invalid format: expected "VERSION:\\d.\\d" but found "'+ version +'"'
       )


### PR DESCRIPTION
…es instead of deleting them by using shift and pop which manipulate the array in place. The original was deleting my address and photo lines in my v-cards (the last two lines). This should fix that bug unless shift() and pop() were there deleting stuff for some other reason that I didn't find.