### PR TITLE
Support the group property of vcard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+yarn.lock

--- a/lib/parse-lines.js
+++ b/lib/parse-lines.js
@@ -55,12 +55,14 @@ function parseLines( lines ) {
     var match = pattern.exec( line )
     if( !match ) continue;
 
-    var property = match[1]
+    var groupAndProperty = match[1].split('.')
+    var property = groupAndProperty[ groupAndProperty.length - 1 ]
+    var group = groupAndProperty[ groupAndProperty.length - 2 ]
     var value = match[3]
     var params = match[2] ?
       match[2].replace( /^;|;$/g, '' ).split( ';' ) : []
 
-    var propParams = params.reduce( createParams, {})
+    var propParams = params.reduce( createParams, group ? { group: group } : {})
     var propName = camelCase( property )
     var propVal = new Property( propName, value, propParams )
 

--- a/lib/parse-lines.js
+++ b/lib/parse-lines.js
@@ -55,9 +55,9 @@ function parseLines( lines ) {
     var match = pattern.exec( line )
     if( !match ) continue;
 
-    var groupAndProperty = match[1].split('.')
-    var property = groupAndProperty[ groupAndProperty.length - 1 ]
-    var group = groupAndProperty[ groupAndProperty.length - 2 ]
+    var name = match[1].split('.')
+    var property = name.pop()
+    var group = name.pop()
     var value = match[3]
     var params = match[2] ?
       match[2].replace( /^;|;$/g, '' ).split( ';' ) : []

--- a/lib/property.js
+++ b/lib/property.js
@@ -96,11 +96,12 @@ Property.prototype = {
    */
   toString: function( version ) {
 
-    var propName = capitalDashCase( this._field )
+    var propName = (this.group ? this.group + '.' : '') + capitalDashCase( this._field )
     var keys = Object.keys( this )
     var params = []
 
     for( var i = 0; i < keys.length; i++ ) {
+      if (keys[i] === 'group') continue
       params.push( capitalDashCase( keys[i] ) + '=' + this[ keys[i] ] )
     }
 

--- a/test/data/jcard.json
+++ b/test/data/jcard.json
@@ -8,7 +8,8 @@
     [ "photo", { "mediatype": "image/gif" }, "uri", "http://www.example.com/dir_photos/my_photo.gif" ],
     [ "tel", { "type": [ "work", "voice" ] }, "uri", "tel:+1-111-555-1212" ],
     [ "tel", { "type": [ "home", "voice" ] }, "uri", "tel:+1-404-555-1212" ],
-    [ 
+    [ "tel", { "type": [ "home", "voice" ], "group": "item1" }, "uri", "tel:+1-404-555-1213" ],
+    [
       "adr", { "type": "work", "label": "100 Waters Edge\nBaytown, LA 30314\nUnited States of America" },
       "text", [ "", "", "100 Waters Edge", "Baytown", "LA", "30314", "United States of America" ]
     ],

--- a/test/data/vcard-4.0.vcf
+++ b/test/data/vcard-4.0.vcf
@@ -7,6 +7,7 @@ TITLE:Shrimp Man
 PHOTO;MEDIATYPE=image/gif:http://www.example.com/dir_photos/my_photo.gif
 TEL;TYPE=work,voice;VALUE=uri:tel:+11115551212
 TEL;TYPE=home,voice;VALUE=uri:tel:+14045551212
+item1.TEL;TYPE=home,voice;VALUE=uri:tel:+14045551213
 ADR;TYPE=work;LABEL="100 Waters Edge\nBaytown, LA 30314\nUnited States of A
  merica":;;100 Waters Edge;Baytown;LA;30314;United States of America
 ADR;TYPE=home;LABEL="42 Plantation St.\nBaytown, LA 30314\nUnited States of

--- a/test/index.js
+++ b/test/index.js
@@ -50,6 +50,10 @@ suite( 'vCard', function() {
       assert.ok( card.get( 'tel' )[0] instanceof vCard.Property )
     })
 
+    test( 'group properties', function() {
+      assert.ok( card.get( 'tel' )[2].group === 'item1' )
+    })
+
     test( 'get() should return property clones', function() {
       assert.notStrictEqual( card.data.email, card.get( 'email' ) )
     })

--- a/test/index.js
+++ b/test/index.js
@@ -117,6 +117,12 @@ suite( 'vCard', function() {
       assert.ok( !/TEL/i.test( card.toString() ) )
     })
 
+    test( 'toString() should render properties with group by prefixing the group to the property name', function() {
+      var card = new vCard()
+      card.set( 'tel', '000' , { group: 'item1' })
+      assert.ok( /item1.TEL:000/i.test( card.toString() ) )
+    })
+
   })
 
 })


### PR DESCRIPTION
This pull request is to support the VCard `group` property as defined in [RFC 6350 Section 3.3](https://tools.ietf.org/html/rfc6350#page-7) by adding a group parameter in the jCard representation explained in [RFC 7095 Section 3.3.1.2](https://tools.ietf.org/html/rfc7095#section-3.3.1.2).

Previous `node-vcf` converted a property name such as `item1.name` to `item1Name`. The expected result would be for the property name to be `name` and for it to belong to the group `item1`. The property name now will behave as expected and the group is exposed is the second item of the property description array under the `group` key.