### PR TITLE
feat(lib): Change .parseMultiple() -> .parse()

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ var vCard = require( 'vcf' )
 ### Parsing a Single vCard
 
 ```js
-var card = vCard.parse( string )
+var card = new vCard().parse( string )
 ```
 
 ```js
@@ -60,19 +60,10 @@ vCard {
 }
 ```
 
-Note: in future versions the return value may be changed to an array (still under discussion), so we recommend changing your return handling to, in order to protect yourself:
-
-```js
-var cards = vCard.parse( string );
-if (!Array.isArray(cards)) {
-   // treat returned object as a single vCard
-} else {
-   // treat returned object as an array of vCards
-}
-```
 ### Parsing Multiple vCards
 
-In order to deal with a string that contains multiple vCards, you will need to use a different function, which returns an array of cards:
+In order to deal with a string that contains multiple vCards,
+you will need to use a different function, which returns an array of cards:
 
 ```js
 var cards = vCard.parseMultiple( string )
@@ -146,33 +137,38 @@ END:VCARD
 ```
 
 ## API Reference
-## Classes
-
-<dl>
-<dt><a href="#vCard">vCard</a></dt>
-<dd></dd>
-</dl>
-
 <a name="vCard"></a>
 
 ## vCard
-**Kind**: global class
+**Kind**: global class  
 
 * [vCard](#vCard)
     * [new vCard()](#new_vCard_new)
     * _instance_
-        * [.get(key)](#vCard+get) ⇒ <code>Object</code> &#124; <code>Array</code>
+        * [.version](#vCard+version) : <code>String</code>
+        * [.data](#vCard+data) : <code>Object</code>
+        * [.get(key)](#vCard+get) ⇒ <code>Object</code> \| <code>Array</code>
         * [.set(key, value, params)](#vCard+set)
         * [.add(key, value, params)](#vCard+add)
         * [.setProperty(prop)](#vCard+setProperty)
         * [.addProperty(prop)](#vCard+addProperty)
-        * [.parse(value)](#vCard+parse) ⇒ <code>[vCard](#vCard)</code>
+        * [.parse(value)](#vCard+parse) ⇒ [<code>vCard</code>](#vCard)
         * [.toString(version, charset)](#vCard+toString) ⇒ <code>String</code>
         * [.toJCard(version)](#vCard+toJCard) ⇒ <code>Array</code>
         * [.toJSON()](#vCard+toJSON) ⇒ <code>Array</code>
     * _static_
-        * [.Property](#vCard.Property) : <code>function</code>
-            * [new vCard.Property()](#new_vCard.Property_new)
+        * [.Property](#vCard.Property)
+            * [new Property(field, value, params)](#new_vCard.Property_new)
+            * _instance_
+                * [.is(type)](#vCard.Property+is) ⇒ <code>Boolean</code>
+                * [.isEmpty()](#vCard.Property+isEmpty) ⇒ <code>Boolean</code>
+                * [.clone()](#vCard.Property+clone) ⇒ <code>Property</code>
+                * [.toString(version)](#vCard.Property+toString) ⇒ <code>String</code>
+                * [.valueOf()](#vCard.Property+valueOf) ⇒ <code>String</code>
+                * [.toJSON()](#vCard.Property+toJSON) ⇒ <code>Array</code>
+            * _static_
+                * [.prototype](#vCard.Property.prototype) : <code>Object</code>
+                * [.fromJSON(data)](#vCard.Property.fromJSON) ⇒ <code>Property</code>
         * [.mimeType](#vCard.mimeType) : <code>String</code>
         * [.extension](#vCard.extension) : <code>String</code>
         * [.versions](#vCard.versions) : <code>Array</code>
@@ -180,52 +176,84 @@ END:VCARD
         * [.parseLines](#vCard.parseLines) : <code>function</code>
         * [.normalize(input)](#vCard.normalize) ⇒ <code>String</code>
         * [.isSupported(version)](#vCard.isSupported) ⇒ <code>Boolean</code>
-        * [.parse(input)](#vCard.parse) ⇒ <code>[vCard](#vCard)</code>
-        * [.parseMultiple(value)](#vCard.parseMultiple) ⇒ <code>Array</code>
-        * [.fromJSON(jcard)](#vCard.fromJSON) ⇒ <code>[vCard](#vCard)</code>
+        * [.parse(value)](#vCard.parse) ⇒ [<code>Array.&lt;vCard&gt;</code>](#vCard)
+        * [.fromJSON(jcard)](#vCard.fromJSON) ⇒ [<code>vCard</code>](#vCard)
         * [.format(card, version)](#vCard.format) ⇒ <code>String</code>
+
+
+* * *
 
 <a name="new_vCard_new"></a>
 
 ### new vCard()
 vCard
 
+
+* * *
+
+<a name="vCard+version"></a>
+
+### vCard.version : <code>String</code>
+Version number
+
+**Kind**: instance property of [<code>vCard</code>](#vCard)  
+
+* * *
+
+<a name="vCard+data"></a>
+
+### vCard.data : <code>Object</code>
+Card data
+
+**Kind**: instance property of [<code>vCard</code>](#vCard)  
+
+* * *
+
 <a name="vCard+get"></a>
 
-### vCard.get(key) ⇒ <code>Object</code> &#124; <code>Array</code>
+### vCard.get(key) ⇒ <code>Object</code> \| <code>Array</code>
 Get a vCard property
 
-**Kind**: instance method of <code>[vCard](#vCard)</code>
+**Kind**: instance method of [<code>vCard</code>](#vCard)  
 
 | Param | Type |
 | --- | --- |
-| key | <code>String</code> |
+| key | <code>String</code> | 
+
+
+* * *
 
 <a name="vCard+set"></a>
 
 ### vCard.set(key, value, params)
 Set a vCard property
 
-**Kind**: instance method of <code>[vCard](#vCard)</code>
+**Kind**: instance method of [<code>vCard</code>](#vCard)  
 
 | Param | Type |
 | --- | --- |
-| key | <code>String</code> |
-| value | <code>String</code> |
-| params | <code>Object</code> |
+| key | <code>String</code> | 
+| value | <code>String</code> | 
+| params | <code>Object</code> | 
+
+
+* * *
 
 <a name="vCard+add"></a>
 
 ### vCard.add(key, value, params)
 Add a vCard property
 
-**Kind**: instance method of <code>[vCard](#vCard)</code>
+**Kind**: instance method of [<code>vCard</code>](#vCard)  
 
 | Param | Type |
 | --- | --- |
-| key | <code>String</code> |
-| value | <code>String</code> |
-| params | <code>Object</code> |
+| key | <code>String</code> | 
+| value | <code>String</code> | 
+| params | <code>Object</code> | 
+
+
+* * *
 
 <a name="vCard+setProperty"></a>
 
@@ -233,11 +261,14 @@ Add a vCard property
 Set a vCard property from an already
 constructed vCard.Property
 
-**Kind**: instance method of <code>[vCard](#vCard)</code>
+**Kind**: instance method of [<code>vCard</code>](#vCard)  
 
 | Param | Type |
 | --- | --- |
-| prop | <code>[Property](#vCard.Property)</code> |
+| prop | [<code>Property</code>](#vCard.Property) | 
+
+
+* * *
 
 <a name="vCard+addProperty"></a>
 
@@ -245,178 +276,313 @@ constructed vCard.Property
 Add a vCard property from an already
 constructed vCard.Property
 
-**Kind**: instance method of <code>[vCard](#vCard)</code>
+**Kind**: instance method of [<code>vCard</code>](#vCard)  
 
 | Param | Type |
 | --- | --- |
-| prop | <code>[Property](#vCard.Property)</code> |
+| prop | [<code>Property</code>](#vCard.Property) | 
+
+
+* * *
 
 <a name="vCard+parse"></a>
 
-### vCard.parse(value) ⇒ <code>[vCard](#vCard)</code>
+### vCard.parse(value) ⇒ [<code>vCard</code>](#vCard)
 Parse a vcf formatted vCard
 
-**Kind**: instance method of <code>[vCard](#vCard)</code>
+**Kind**: instance method of [<code>vCard</code>](#vCard)  
 
 | Param | Type |
 | --- | --- |
-| value | <code>String</code> |
+| value | <code>String</code> | 
+
+
+* * *
 
 <a name="vCard+toString"></a>
 
 ### vCard.toString(version, charset) ⇒ <code>String</code>
 Format the vCard as vcf with given version
 
-**Kind**: instance method of <code>[vCard](#vCard)</code>
+**Kind**: instance method of [<code>vCard</code>](#vCard)  
 
 | Param | Type |
 | --- | --- |
-| version | <code>String</code> |
-| charset | <code>String</code> |
+| version | <code>String</code> | 
+| charset | <code>String</code> | 
+
+
+* * *
 
 <a name="vCard+toJCard"></a>
 
 ### vCard.toJCard(version) ⇒ <code>Array</code>
 Format the card as jCard
 
-**Kind**: instance method of <code>[vCard](#vCard)</code>
-**Returns**: <code>Array</code> - jCard
+**Kind**: instance method of [<code>vCard</code>](#vCard)  
+**Returns**: <code>Array</code> - jCard  
 
 | Param | Type | Default |
 | --- | --- | --- |
-| version | <code>String</code> | <code>&#x27;4.0&#x27;</code> |
+| version | <code>String</code> | <code>&#x27;4.0&#x27;</code> | 
+
+
+* * *
 
 <a name="vCard+toJSON"></a>
 
 ### vCard.toJSON() ⇒ <code>Array</code>
 Format the card as jCard
 
-**Kind**: instance method of <code>[vCard](#vCard)</code>
-**Returns**: <code>Array</code> - jCard
+**Kind**: instance method of [<code>vCard</code>](#vCard)  
+**Returns**: <code>Array</code> - jCard  
+
+* * *
+
 <a name="vCard.Property"></a>
 
-### vCard.Property : <code>function</code>
-**Kind**: static class of <code>[vCard](#vCard)</code>
+### vCard.Property
+**Kind**: static class of [<code>vCard</code>](#vCard)  
+
+* [.Property](#vCard.Property)
+    * [new Property(field, value, params)](#new_vCard.Property_new)
+    * _instance_
+        * [.is(type)](#vCard.Property+is) ⇒ <code>Boolean</code>
+        * [.isEmpty()](#vCard.Property+isEmpty) ⇒ <code>Boolean</code>
+        * [.clone()](#vCard.Property+clone) ⇒ <code>Property</code>
+        * [.toString(version)](#vCard.Property+toString) ⇒ <code>String</code>
+        * [.valueOf()](#vCard.Property+valueOf) ⇒ <code>String</code>
+        * [.toJSON()](#vCard.Property+toJSON) ⇒ <code>Array</code>
+    * _static_
+        * [.prototype](#vCard.Property.prototype) : <code>Object</code>
+        * [.fromJSON(data)](#vCard.Property.fromJSON) ⇒ <code>Property</code>
+
+
+* * *
+
 <a name="new_vCard.Property_new"></a>
 
-#### new vCard.Property()
-vCard Property constructor
+#### new Property(field, value, params)
+vCard Property
+
+
+| Param | Type |
+| --- | --- |
+| field | <code>String</code> | 
+| value | <code>String</code> | 
+| params | <code>Object</code> | 
+
+
+* * *
+
+<a name="vCard.Property+is"></a>
+
+#### property.is(type) ⇒ <code>Boolean</code>
+Check whether the property is of a given type
+
+**Kind**: instance method of [<code>Property</code>](#vCard.Property)  
+
+| Param | Type |
+| --- | --- |
+| type | <code>String</code> | 
+
+
+* * *
+
+<a name="vCard.Property+isEmpty"></a>
+
+#### property.isEmpty() ⇒ <code>Boolean</code>
+Check whether the property is empty
+
+**Kind**: instance method of [<code>Property</code>](#vCard.Property)  
+
+* * *
+
+<a name="vCard.Property+clone"></a>
+
+#### property.clone() ⇒ <code>Property</code>
+Clone the property
+
+**Kind**: instance method of [<code>Property</code>](#vCard.Property)  
+
+* * *
+
+<a name="vCard.Property+toString"></a>
+
+#### property.toString(version) ⇒ <code>String</code>
+Format the property as vcf with given version
+
+**Kind**: instance method of [<code>Property</code>](#vCard.Property)  
+
+| Param | Type |
+| --- | --- |
+| version | <code>String</code> | 
+
+
+* * *
+
+<a name="vCard.Property+valueOf"></a>
+
+#### property.valueOf() ⇒ <code>String</code>
+Get the property's value
+
+**Kind**: instance method of [<code>Property</code>](#vCard.Property)  
+
+* * *
+
+<a name="vCard.Property+toJSON"></a>
+
+#### property.toJSON() ⇒ <code>Array</code>
+Format the property as jCard data
+
+**Kind**: instance method of [<code>Property</code>](#vCard.Property)  
+
+* * *
+
+<a name="vCard.Property.prototype"></a>
+
+#### Property.prototype : <code>Object</code>
+Property prototype
+
+**Kind**: static property of [<code>Property</code>](#vCard.Property)  
+
+* * *
+
+<a name="vCard.Property.fromJSON"></a>
+
+#### Property.fromJSON(data) ⇒ <code>Property</code>
+Constructs a vCard.Property from jCard data
+
+**Kind**: static method of [<code>Property</code>](#vCard.Property)  
+
+| Param | Type |
+| --- | --- |
+| data | <code>Array</code> | 
+
+
+* * *
 
 <a name="vCard.mimeType"></a>
 
 ### vCard.mimeType : <code>String</code>
 vCard MIME type
 
-**Kind**: static property of <code>[vCard](#vCard)</code>
+**Kind**: static property of [<code>vCard</code>](#vCard)  
+
+* * *
+
 <a name="vCard.extension"></a>
 
 ### vCard.extension : <code>String</code>
 vCard file extension
 
-**Kind**: static property of <code>[vCard](#vCard)</code>
+**Kind**: static property of [<code>vCard</code>](#vCard)  
+
+* * *
+
 <a name="vCard.versions"></a>
 
 ### vCard.versions : <code>Array</code>
 vCard versions
 
-**Kind**: static property of <code>[vCard](#vCard)</code>
+**Kind**: static property of [<code>vCard</code>](#vCard)  
+
+* * *
+
 <a name="vCard.foldLine"></a>
 
 ### vCard.foldLine ⇒ <code>String</code>
 Folds a long line according to the RFC 5322.
 
-**Kind**: static property of <code>[vCard](#vCard)</code>
-**See**: http://tools.ietf.org/html/rfc5322#section-2.1.1
+**Kind**: static property of [<code>vCard</code>](#vCard)  
+**See**: http://tools.ietf.org/html/rfc5322#section-2.1.1  
 
 | Param | Type |
 | --- | --- |
-| input | <code>String</code> |
-| maxLength | <code>Number</code> |
-| hardWrap | <code>Boolean</code> |
+| input | <code>String</code> | 
+| maxLength | <code>Number</code> | 
+| hardWrap | <code>Boolean</code> | 
+
+
+* * *
 
 <a name="vCard.parseLines"></a>
 
 ### vCard.parseLines : <code>function</code>
 Parse an array of vcf formatted lines
 
-**Kind**: static property of <code>[vCard](#vCard)</code>
-**Internal**: used by `vCard#parse()`
+**Kind**: static property of [<code>vCard</code>](#vCard)  
+**Internal**: used by `vCard#parse()`  
+
+* * *
+
 <a name="vCard.normalize"></a>
 
 ### vCard.normalize(input) ⇒ <code>String</code>
 Normalizes input (cast to string, line folding, whitespace)
 
-**Kind**: static method of <code>[vCard](#vCard)</code>
+**Kind**: static method of [<code>vCard</code>](#vCard)  
 
 | Param | Type |
 | --- | --- |
-| input | <code>String</code> |
+| input | <code>String</code> | 
+
+
+* * *
 
 <a name="vCard.isSupported"></a>
 
 ### vCard.isSupported(version) ⇒ <code>Boolean</code>
 Check whether a given version is supported
 
-**Kind**: static method of <code>[vCard](#vCard)</code>
+**Kind**: static method of [<code>vCard</code>](#vCard)  
 
 | Param | Type |
 | --- | --- |
-| version | <code>String</code> |
+| version | <code>String</code> | 
+
+
+* * *
 
 <a name="vCard.parse"></a>
 
-### vCard.parse(input) ⇒ <code>[vCard](#vCard)</code>
+### vCard.parse(value) ⇒ [<code>Array.&lt;vCard&gt;</code>](#vCard)
 Parses a string or buffer into a vCard object
 
-**Kind**: static method of <code>[vCard](#vCard)</code>
+**Kind**: static method of [<code>vCard</code>](#vCard)  
 
 | Param | Type |
 | --- | --- |
-| input | <code>String</code> &#124; <code>Buffer</code> |
+| value | <code>String</code> \| <code>Buffer</code> | 
 
-<a name="vCard.parseMultiple"></a>
 
-### vCard.parseMultiple(value) ⇒ <code>Array</code>
-Parses multiple vCards from one value
-
-**Kind**: static method of <code>[vCard](#vCard)</code>
-**Returns**: <code>Array</code> - cards
-
-| Param | Type |
-| --- | --- |
-| value | <code>String</code> |
+* * *
 
 <a name="vCard.fromJSON"></a>
 
-### vCard.fromJSON(jcard) ⇒ <code>[vCard](#vCard)</code>
+### vCard.fromJSON(jcard) ⇒ [<code>vCard</code>](#vCard)
 Constructs a vCard from jCard data
 
-**Kind**: static method of <code>[vCard](#vCard)</code>
+**Kind**: static method of [<code>vCard</code>](#vCard)  
 
 | Param | Type |
 | --- | --- |
-| jcard | <code>Array</code> |
+| jcard | <code>Array</code> | 
+
+
+* * *
 
 <a name="vCard.format"></a>
 
 ### vCard.format(card, version) ⇒ <code>String</code>
 Format a card object according to the given version
 
-**Kind**: static method of <code>[vCard](#vCard)</code>
+**Kind**: static method of [<code>vCard</code>](#vCard)  
 
 | Param | Type |
 | --- | --- |
-| card | <code>[vCard](#vCard)</code> |
-| version | <code>String</code> |
+| card | [<code>vCard</code>](#vCard) | 
+| version | <code>String</code> | 
 
-<a name="capitalDashCase"></a>
 
-## capitalDashCase(value) ⇒ <code>String</code>
-Turn a string into capitalized dash-case
-
-**Kind**: global function
-**Internal**: used by `Property#toString()`
-
-| Param | Type |
-| --- | --- |
-| value | <code>String</code> |
+* * *

--- a/lib/property.js
+++ b/lib/property.js
@@ -1,6 +1,7 @@
 /**
  * vCard Property
  * @constructor
+ * @memberOf vCard
  * @param {String} field
  * @param {String} value
  * @param {Object} params
@@ -47,6 +48,7 @@ Property.fromJSON = function( data ) {
  * @internal used by `Property#toString()`
  * @param  {String} value
  * @return {String}
+ * @ignore
  */
 function capitalDashCase( value ) {
   return value.replace( /([A-Z])/g, '-$1' ).toUpperCase()

--- a/lib/vcard.js
+++ b/lib/vcard.js
@@ -8,7 +8,9 @@ function vCard() {
   if( !(this instanceof vCard) )
     return new vCard()
 
+  /** @type {String} Version number */
   this.version = vCard.versions[ vCard.versions.length - 1 ]
+  /** @type {Object} Card data */
   this.data = {}
 
 }
@@ -158,11 +160,7 @@ vCard.format = function( card, version ) {
 
 }
 
-/**
- * vCard Property constructor
- * @constructor
- * @type {Function}
- */
+// vCard Property constructor
 vCard.Property = require( './property' )
 
 /**

--- a/lib/vcard.js
+++ b/lib/vcard.js
@@ -68,11 +68,20 @@ vCard.isSupported = function( version ) {
 
 /**
  * Parses a string or buffer into a vCard object
- * @param  {String|Buffer} input
- * @return {vCard}
+ * @param  {String|Buffer} value
+ * @return {Array<vCard>}
  */
-vCard.parse = function( input ) {
-  return new vCard().parse( input )
+vCard.parse = function( value ) {
+
+  var objects = ( value + '' ).split( /(?=BEGIN\:VCARD)/gi )
+  var cards = []
+
+  for( var i = 0; i < objects.length; i++ ) {
+    cards.push( new vCard().parse( objects[i] ) )
+  }
+
+  return cards
+
 }
 
 /**
@@ -81,17 +90,6 @@ vCard.parse = function( input ) {
  * @type {Function}
  */
 vCard.parseLines = require( './parse-lines' )
-
-/**
- * Parses multiple vCards from one value
- * @param  {String} value
- * @return {Array}  cards
- */
-vCard.parseMultiple = function( value ) {
-  return ( value + '' )
-    .split( /(?=BEGIN\:VCARD)/gi )
-    .map( vCard.parse )
-}
 
 /**
  * Constructs a vCard from jCard data

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "matcha": "~0.7.0",
-    "mocha": "~3.2.0"
+    "mocha": "^3.4.2"
   },
   "testling": {
     "harness": "mocha-tdd",

--- a/test/anomalies.js
+++ b/test/anomalies.js
@@ -8,7 +8,7 @@ suite( 'vCard', function() {
 
     test( 'should parse a vCard with empty lines (android)', function() {
       var data = fs.readFileSync( __dirname + '/data/empty-lines.vcf' )
-      var card = vCard.parse( data )
+      var card = new vCard().parse( data )
       assert.ok( card.get( 'rev' ) )
       assert.ok( card.get( 'photo' ) )
       assert.strictEqual( card.get( 'tel' ).length, 2 )

--- a/test/collection.js
+++ b/test/collection.js
@@ -8,7 +8,7 @@ suite( 'vCard', function() {
 
     test( 'Parses multiple vCards form one file', function() {
       var data = fs.readFileSync( __dirname + '/data/multiple.vcf' )
-      var cards = vCard.parseMultiple( data )
+      var cards = vCard.parse( data )
       assert.equal( cards.length, 3 )
     })
 

--- a/test/index.js
+++ b/test/index.js
@@ -21,7 +21,7 @@ suite( 'vCard', function() {
 
     suiteSetup( 'parse', function() {
       var data = fs.readFileSync( __dirname + '/data/vcard-4.0.vcf' )
-      card = vCard.parse( data )
+      card = new vCard().parse( data )
     })
 
     test( 'should not have BEGIN as property', function() {

--- a/test/markers.js
+++ b/test/markers.js
@@ -8,44 +8,38 @@ suite( 'vCard', function() {
 
     test( 'should throw on missing BEGIN marker', function() {
       var data = 'VERSION:4.0\nURL;TYPE=work:http://www.example.comEND:VCARD\n'
-      assert.throws( function() {
-        vCard.parse( data )
-      })
+      var card = new vCard()
+      assert.throws( function() { card.parse( data ) })
     })
 
     test( 'should throw on misplaced BEGIN marker', function() {
       var data = 'VERSION:4.0\nBEGIN:VCARD\nURL;TYPE=work:http://www.example.comEND:VCARD\n'
-      assert.throws( function() {
-        vCard.parse( data )
-      })
+      var card = new vCard()
+      assert.throws( function() { card.parse( data ) })
     })
 
     test( 'should throw on missing VERSION marker', function() {
       var data = 'BEGIN:VCARD\nURL;TYPE=work:http://www.example.comEND:VCARD\n'
-      assert.throws( function() {
-        vCard.parse( data )
-      })
+      var card = new vCard()
+      assert.throws( function() { card.parse( data ) })
     })
 
     test( 'should throw on misplaced VERSION marker', function() {
       var data = 'BEGIN:VCARD\nURL;TYPE=work:http://www.example.com\nVERSION:4.0\nEND:VCARD\n'
-      assert.throws( function() {
-        vCard.parse( data )
-      })
+      var card = new vCard()
+      assert.throws( function() { card.parse( data ) })
     })
 
     test( 'should throw on missing END marker', function() {
       var data = 'BEGIN:VCARD\nVERSION:4.0\nURL;TYPE=work:http://www.example.com\n'
-      assert.throws( function() {
-        vCard.parse( data )
-      })
+      var card = new vCard()
+      assert.throws( function() { card.parse( data ) })
     })
 
     test( 'should throw on misplaced END marker', function() {
       var data = 'BEGIN:VCARD\nVERSION:4.0\nEND:VCARD\nURL;TYPE=work:http://www.example.com\n'
-      assert.throws( function() {
-        vCard.parse( data )
-      })
+      var card = new vCard()
+      assert.throws( function() { card.parse( data ) })
     })
 
   })

--- a/test/photo.js
+++ b/test/photo.js
@@ -15,7 +15,7 @@ suite( 'vCard', function() {
 
     test( 'should be able to read base64 encoded photo', function() {
       var data = fs.readFileSync( __dirname + '/data/photo-base64.vcf' )
-      var card = vCard.parse( data )
+      var card = new vCard().parse( data )
       var photo = card.get( 'photo' )
       assert.ok( photo instanceof vCard.Property )
       assert.equal( photo.encoding, 'BASE64' )


### PR DESCRIPTION
This should make dealing with multiple vCards in inputs easier by defaulting to parsing multiple vCards in `.parse()`, as discussed in https://github.com/jhermsmeier/node-vcf/issues/11

**Changes:**

- **BREAKING**: Removed `vCard.parseMultiple()`
- **BREAKING**: `vCard.parse()` now returns `Array<vCard>`
- Updated API reference in `README.md`