### PR TITLE
downgrade camelcase dependency to keep better browser support

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://jhermsmeier.de"
   },
   "dependencies": {
-    "camelcase": "~4.1.0",
+    "camelcase": "~3.0.0",
     "foldline": "~1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Related Issue: #18 

Author of camelcase library decided to support only modern browsers since 4.0 version.
https://github.com/sindresorhus/camelcase/issues/19
Therefore node-vcf required the use of transpiler to make it work in old browsers.

This PR downgrades camelcase to fix this.

