### PR TITLE
Ensure that property.is(type) actually returns a boolean

### DIFF
--- a/lib/property.js
+++ b/lib/property.js
@@ -69,7 +69,7 @@ Property.prototype = {
    */
   is: function( type ) {
     type = ( type + '' ).toLowerCase()
-    return Array.isArray( type ) ?
+    return Array.isArray( this.type ) ?
       this.type.indexOf( type ) >= 0 :
       this.type === type
   },

--- a/lib/property.js
+++ b/lib/property.js
@@ -69,8 +69,8 @@ Property.prototype = {
    */
   is: function( type ) {
     type = ( type + '' ).toLowerCase()
-    return Array.isArray( this.type ) ?
-      this.type.indexOf( type ) :
+    return Array.isArray( type ) ?
+      type.indexOf( type ) >= 0 :
       this.type === type
   },
 

--- a/lib/property.js
+++ b/lib/property.js
@@ -70,7 +70,7 @@ Property.prototype = {
   is: function( type ) {
     type = ( type + '' ).toLowerCase()
     return Array.isArray( type ) ?
-      type.indexOf( type ) >= 0 :
+      this.type.indexOf( type ) >= 0 :
       this.type === type
   },
 


### PR DESCRIPTION
Currently, the `property.is(type)` returns a `-1` and not a boolean in case `this.type` is an array and `type` is not found. Similarly, it returns an integer in case it is found.

This PR ensures that it returns a boolean in any case.