### PR TITLE
Fix to support parsing of "quoted-printable" encoded property values

### DIFF
--- a/lib/parse-lines.js
+++ b/lib/parse-lines.js
@@ -47,7 +47,7 @@ function parseLines( lines ) {
   // NOTE: Line format:
   //  PROPERTY[;PARAMETER[=VALUE]]:Attribute[;Attribute]
   var line = null
-  var pattern = /^([^;:]+)((?:;(?:[^;:]+))*)(?:\:(.+))?$/i
+  var pattern = /^([^;:]+)((?:;(?:[^;:]+))*)(?:\:([\s\S]+))?$/i
   var len = lines.length - 1
 
   for( var i = 1; i < len; i++ ) {

--- a/lib/vcard.js
+++ b/lib/vcard.js
@@ -254,7 +254,7 @@ vCard.prototype = {
 
     // Normalize & split
     var lines = vCard.normalize( value )
-      .split( /\r?\n/g )
+      .split( /\r\n/g )
 
     // Keep begin and end markers
     // for eventual error messages

--- a/test/anomalies.js
+++ b/test/anomalies.js
@@ -33,8 +33,8 @@ suite( 'vCard', function() {
     })
 
     test( 'should parse vCard property values containing isolated \\n without delimiting, e.g. used in quoted-printable encoding (issue #31)', function() {
-      let data = vCard_withQuotedPrintableEncoding;
-      let card = new vCard().parse( data );
+      var data = vCard_withQuotedPrintableEncoding;
+      var card = new vCard().parse( data );
       assert.strictEqual(card.get( 'note' ).valueOf(), 'foobar foobar foobar foobar fo=\nobar foobar foobar foobar foobar=0Afoobar foobar foobar foobar foobar fooba=\nr=0Afoobar foobar foobar foobar foobar foobar=0Afoobar foobar foobar foobar=\n foobar foobar foobar foobar foobar')
     })
 

--- a/test/anomalies.js
+++ b/test/anomalies.js
@@ -1,6 +1,7 @@
 var vCard = require( '..' )
 var fs = require( 'fs' )
 var assert = require( 'assert' )
+var vCard_withQuotedPrintableEncoding = require( './data/vcard-withQuotedPrintableEncoding' )
 
 suite( 'vCard', function() {
 
@@ -29,6 +30,12 @@ suite( 'vCard', function() {
       var data = fs.readFileSync( __dirname + '/data/quoted-list.vcf' )
       var card = new vCard().parse( data )
       assert.deepEqual( card.get( 'tel' ).type, [ 'voice', 'home' ] )
+    })
+
+    test( 'should parse vCard property values containing isolated \\n without delimiting, e.g. used in quoted-printable encoding (issue #31)', function() {
+      let data = vCard_withQuotedPrintableEncoding;
+      let card = new vCard().parse( data );
+      assert.strictEqual(card.get( 'note' ).valueOf(), 'foobar foobar foobar foobar fo=\nobar foobar foobar foobar foobar=0Afoobar foobar foobar foobar foobar fooba=\nr=0Afoobar foobar foobar foobar foobar foobar=0Afoobar foobar foobar foobar=\n foobar foobar foobar foobar foobar')
     })
 
   })

--- a/test/data/vcard-withQuotedPrintableEncoding.js
+++ b/test/data/vcard-withQuotedPrintableEncoding.js
@@ -1,0 +1,22 @@
+module.exports =
+  'BEGIN:VCARD\r\n' +
+  'VERSION:4.0\r\n' +
+  'N:Gump;Forrest;;;\r\n' +
+  'FN:Forrest Gump\r\n' +
+  'ORG:Bubba Gump Shrimp Co.\r\n' +
+  'TITLE:Shrimp Man\r\n' +
+  'PHOTO;MEDIATYPE=image/gif:http://www.example.com/dir_photos/my_photo.gif\r\n' +
+  'TEL;TYPE=work,voice;VALUE=uri:tel:+11115551212\r\n' +
+  'TEL;TYPE=home,voice;VALUE=uri:tel:+14045551212\r\n' +
+  'item1.TEL;TYPE=home,voice;VALUE=uri:tel:+14045551213\r\n' +
+  'ADR;TYPE=work;LABEL="100 Waters Edge\\nBaytown, LA 30314\\nUnited States of A\r\n' +
+  ' merica":;;100 Waters Edge;Baytown;LA;30314;United States of America\r\n' +
+  'ADR;TYPE=home;LABEL="42 Plantation St.\\nBaytown, LA 30314\\nUnited States of\r\n' +
+  '  America":;;42 Plantation St.;Baytown;LA;30314;United States of America\r\n' +
+  'EMAIL:forrestgump@example.com\r\n' +
+  'NOTE;ENCODING=QUOTED-PRINTABLE;CHARSET=utf-8:foobar foobar foobar foobar fo=\n' +
+  'obar foobar foobar foobar foobar=0Afoobar foobar foobar foobar foobar fooba=\n' +
+  'r=0Afoobar foobar foobar foobar foobar foobar=0Afoobar foobar foobar foobar=\n' +
+  ' foobar foobar foobar foobar foobar\r\n' +
+  'REV:20080424T195243Z\r\n' +
+  'END:VCARD\r\n';


### PR DESCRIPTION
Example of valid vcard property:
```
NOTE;ENCODING=QUOTED-PRINTABLE;CHARSET=utf-8:foobar foobar foobar foobar fo=
obar foobar foobar foobar foobar=0Afoobar foobar foobar foobar foobar fooba=
r=0Afoobar foobar foobar foobar foobar foobar=0Afoobar foobar foobar foobar=
 foobar foobar foobar foobar foobar
```

---

With "visible" EOL characters ...:
```
NOTE;ENCODING=QUOTED-PRINTABLE;CHARSET=utf-8:foobar foobar foobar foobar fo=\n
obar foobar foobar foobar foobar=0Afoobar foobar foobar foobar foobar fooba=\n
r=0Afoobar foobar foobar foobar foobar foobar=0Afoobar foobar foobar foobar=\n
 foobar foobar foobar foobar foobar\r\n
```
... or as string:
```
"NOTE;ENCODING=QUOTED-PRINTABLE;CHARSET=utf-8:foobar foobar foobar foobar fo=\nobar foobar foobar foobar foobar=0Afoobar foobar foobar foobar foobar fooba=\nr=0Afoobar foobar foobar foobar foobar foobar=0Afoobar foobar foobar foobar=\n foobar foobar foobar foobar foobar\r\n"
```