### PR TITLE
Basic support for toString method with version 2.1 and 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 yarn.lock
+package-lock.json
+.idea/
+*.iml

--- a/lib/property.js
+++ b/lib/property.js
@@ -104,12 +104,33 @@ Property.prototype = {
 
     for( var i = 0; i < keys.length; i++ ) {
       if (keys[i] === 'group') continue
-      params.push( capitalDashCase( keys[i] ) + '=' + this[ keys[i] ] )
+
+      switch (propName) {
+        case 'TEL':
+        case 'ADR':
+        case 'EMAIL':
+          if (version === '2.1') {
+            if (Array.isArray(this[keys[i]]))
+              params.push(this[keys[i]].join(';'))
+            else
+              params.push(this[keys[i]])
+          }
+          else
+            params.push(capitalDashCase(keys[i]) + '=' + this[keys[i]])
+          break
+        default:
+          params.push(capitalDashCase(keys[i]) + '=' + this[keys[i]])
+      }
     }
 
-    return propName +
-      ( params.length ? ';' + params.join( ';' ) : params ) + ':' +
-      ( Array.isArray( this._data ) ? this._data.join( ';' ) : this._data )
+    if (version === '2.1' || version === '3.0')
+      return propName +
+        ( params.length ? ';' + params.join( ';' ).toUpperCase() : params.toString().toUpperCase() ) + ':' +
+        ( Array.isArray( this._data ) ? this._data.join( ';' ) : this._data )
+    else
+      return propName +
+        ( params.length ? ';' + params.join( ';' ) : params ) + ':' +
+        ( Array.isArray( this._data ) ? this._data.join( ';' ) : this._data )
 
   },
 

--- a/test/vcardVersions.js
+++ b/test/vcardVersions.js
@@ -7,24 +7,30 @@ suite( 'vCard', function() {
   suite( 'vCard Version Strings', function() {
 
     test( 'toString version 4.0 should contain type with lowercase values', function() {
-      var data = fs.readFileSync( __dirname + '/data/vcard-4.0.vcf' )
+      var data = fs.readFileSync( __dirname + '/data/vcard-3.0.vcf' )
       var card = new vCard().parse( data )
       var v40String = card.toString('4.0')
-      assert.notEqual( v40String.indexOf('TEL;TYPE=work,voice;'), -1 )
+      assert.notEqual( v40String.indexOf('TEL;TYPE=work,voice:'), -1 )
+      assert.notEqual( v40String.indexOf('ADR;TYPE=work:'), -1 )
+      assert.notEqual( v40String.indexOf('EMAIL;TYPE=pref,'), -1 )
     })
 
     test( 'toString version 3.0 should contain type with uppercase values', function() {
-      var data = fs.readFileSync( __dirname + '/data/vcard-4.0.vcf' )
+      var data = fs.readFileSync( __dirname + '/data/vcard-3.0.vcf' )
       var card = new vCard().parse( data )
       var v30String = card.toString('3.0')
-      assert.notEqual( v30String.indexOf('TEL;TYPE=WORK,VOICE;'), -1)
+      assert.notEqual( v30String.indexOf('TEL;TYPE=WORK,VOICE:'), -1)
+      assert.notEqual( v30String.indexOf('ADR;TYPE=WORK:'), -1 )
+      assert.notEqual( v30String.indexOf('EMAIL;TYPE=PREF,'), -1 )
     })
 
     test( 'toString version 2.1 should contain values with uppercase but no type string', function() {
-      var data = fs.readFileSync( __dirname + '/data/vcard-4.0.vcf' )
+      var data = fs.readFileSync( __dirname + '/data/vcard-3.0.vcf' )
       var card = new vCard().parse( data )
       var v21String = card.toString('2.1')
-      assert.notEqual( v21String.indexOf('TEL;WORK;VOICE;'), -1)
+      assert.notEqual( v21String.indexOf('TEL;WORK;VOICE:'), -1)
+      assert.notEqual( v21String.indexOf('ADR;WORK:'), -1 )
+      assert.notEqual( v21String.indexOf('EMAIL;PREF;'), -1 )
     })
   })
 

--- a/test/vcardVersions.js
+++ b/test/vcardVersions.js
@@ -1,0 +1,31 @@
+var vCard = require( '..' )
+var fs = require( 'fs' )
+var assert = require( 'assert' )
+
+suite( 'vCard', function() {
+
+  suite( 'vCard Version Strings', function() {
+
+    test( 'toString version 4.0 should contain type with lowercase values', function() {
+      var data = fs.readFileSync( __dirname + '/data/vcard-4.0.vcf' )
+      var card = new vCard().parse( data )
+      var v40String = card.toString('4.0')
+      assert.notEqual( v40String.indexOf('TEL;TYPE=work,voice;'), -1 )
+    })
+
+    test( 'toString version 3.0 should contain type with uppercase values', function() {
+      var data = fs.readFileSync( __dirname + '/data/vcard-4.0.vcf' )
+      var card = new vCard().parse( data )
+      var v30String = card.toString('3.0')
+      assert.notEqual( v30String.indexOf('TEL;TYPE=WORK,VOICE;'), -1)
+    })
+
+    test( 'toString version 2.1 should contain values with uppercase but no type string', function() {
+      var data = fs.readFileSync( __dirname + '/data/vcard-4.0.vcf' )
+      var card = new vCard().parse( data )
+      var v21String = card.toString('2.1')
+      assert.notEqual( v21String.indexOf('TEL;WORK;VOICE;'), -1)
+    })
+  })
+
+})


### PR DESCRIPTION
This pull request add some basic support for differences between version 2.1, 3.0 and 4.0 for the toString() method.
This version support is not perfect but good enough for some of my devices to accept the files created with older versions now.
