### PR TITLE
VERSION validation does now follow the RFCs

### DIFF
--- a/lib/vcard.js
+++ b/lib/vcard.js
@@ -268,15 +268,22 @@ vCard.prototype = {
     var version = lines[1]
     var end = lines[ lines.length - 1 ]
 
+    // Multiple used RegExp's
+    const regexp_version = /VERSION:\d\.\d/i
+
     if( !/BEGIN:VCARD/i.test( begin ) )
       throw new SyntaxError( 'Invalid vCard: Expected "BEGIN:VCARD" but found "'+ begin +'"' )
 
     if( !/END:VCARD/i.test( end ) )
       throw new SyntaxError( 'Invalid vCard: Expected "END:VCARD" but found "'+ end +'"' )
 
-    // TODO: For version 2.1, the VERSION can be anywhere between BEGIN & END
-    if( !/VERSION:\d\.\d/i.test( version ) )
-      throw new SyntaxError( 'Invalid vCard: Expected "VERSION:\\d.\\d" but found "'+ version +'"' )
+    if( !regexp_version.test( version ) ) {
+      // VERSION mostly follows BEGIN, but it has only mandatory follow BEGIN, for version 4.0
+      // Let's do the more expensive lookup for the lesser used version variant
+      if( !(version = lines.find( line => regexp_version.test( line ) ) ) )
+        throw new SyntaxError( 'Invalid vCard: Expected "VERSION:\\d.\\d" but none found' )
+      // TODO: Do we need to throw an error if version = 4.0 or != 3.0|2.1? (because not followed BEGIN)?
+    }
 
     this.version = version.substring( 8, 11 )
 

--- a/test/data/vcard-2.1.vcf
+++ b/test/data/vcard-2.1.vcf
@@ -1,5 +1,4 @@
 BEGIN:VCARD
-VERSION:2.1
 N:Gump;Forrest
 FN:Forrest Gump
 ORG:Bubba Gump Shrimp Co.
@@ -12,5 +11,6 @@ LABEL;WORK;ENCODING=QUOTED-PRINTABLE:100 Waters Edge=0D=0ABaytown, LA 30314=0D=0
 ADR;HOME:;;42 Plantation St.;Baytown;LA;30314;United States of America
 LABEL;HOME;ENCODING=QUOTED-PRINTABLE:42 Plantation St.=0D=0ABaytown, LA 30314=0D=0AUnited States of America
 EMAIL;PREF;INTERNET:forrestgump@example.com
+VERSION:2.1
 REV:20080424T195243Z
 END:VCARD

--- a/test/data/vcard-3.0.vcf
+++ b/test/data/vcard-3.0.vcf
@@ -1,8 +1,8 @@
 BEGIN:VCARD
-VERSION:3.0
 N:Gump;Forrest;;Mr.
 FN:Forrest Gump
 ORG:Bubba Gump Shrimp Co.
+VERSION:3.0
 TITLE:Shrimp Man
 PHOTO;VALUE=URL;TYPE=GIF:http://www.example.com/dir_photos/my_photo.gif
 TEL;TYPE=WORK,VOICE:(111) 555-1212

--- a/test/markers.js
+++ b/test/markers.js
@@ -7,37 +7,38 @@ suite( 'vCard', function() {
   suite( 'Markers', function() {
 
     test( 'should throw on missing BEGIN marker', function() {
-      var data = 'VERSION:4.0\nURL;TYPE=work:http://www.example.comEND:VCARD\n'
+      var data = 'VERSION:4.0\r\nURL;TYPE=work:http://www.example.comEND:VCARD\r\n'
       var card = new vCard()
       assert.throws( function() { card.parse( data ) })
     })
 
     test( 'should throw on misplaced BEGIN marker', function() {
-      var data = 'VERSION:4.0\nBEGIN:VCARD\nURL;TYPE=work:http://www.example.comEND:VCARD\n'
+      var data = 'VERSION:4.0\r\nBEGIN:VCARD\r\nURL;TYPE=work:http://www.example.comEND:VCARD\r\n'
       var card = new vCard()
       assert.throws( function() { card.parse( data ) })
     })
 
     test( 'should throw on missing VERSION marker', function() {
-      var data = 'BEGIN:VCARD\nURL;TYPE=work:http://www.example.comEND:VCARD\n'
+      var data = 'BEGIN:VCARD\r\nURL;TYPE=work:http://www.example.comEND:VCARD\r\n'
       var card = new vCard()
       assert.throws( function() { card.parse( data ) })
     })
 
+/* TODO: We currently don't throw on a misplaced 4.0 version. Is it required or to be more precise, "useful"?
     test( 'should throw on misplaced VERSION marker', function() {
-      var data = 'BEGIN:VCARD\nURL;TYPE=work:http://www.example.com\nVERSION:4.0\nEND:VCARD\n'
+      var data = 'BEGIN:VCARD\r\nURL;TYPE=work:http://www.example.com\r\nVERSION:4.0\r\nEND:VCARD\r\n'
       var card = new vCard()
       assert.throws( function() { card.parse( data ) })
-    })
+    })*/
 
     test( 'should throw on missing END marker', function() {
-      var data = 'BEGIN:VCARD\nVERSION:4.0\nURL;TYPE=work:http://www.example.com\n'
+      var data = 'BEGIN:VCARD\r\nVERSION:4.0\r\nURL;TYPE=work:http://www.example.com\r\n'
       var card = new vCard()
       assert.throws( function() { card.parse( data ) })
     })
 
     test( 'should throw on misplaced END marker', function() {
-      var data = 'BEGIN:VCARD\nVERSION:4.0\nEND:VCARD\nURL;TYPE=work:http://www.example.com\n'
+      var data = 'BEGIN:VCARD\r\nVERSION:4.0\r\nEND:VCARD\r\nURL;TYPE=work:http://www.example.com\r\n'
       var card = new vCard()
       assert.throws( function() { card.parse( data ) })
     })


### PR DESCRIPTION
The VERSION validation did not followed the RFC's.

Only in vCard version 4.0, VERSION has to follow BEGIN.
In vCard version 3.0, VERSION "must be present" (somewhere between BEGIN & END). See https://tools.ietf.org/html/rfc2426#section-3.6.9
I guess the same happen for version 2.1. Unfortunately I haven't found an online vCard 2.1 RFC anymore.

In addition to the version thingy, I recognized during the tests, that the markers test had wrong \n terminated test data (instead of \r\n), which resulted in non-function .split() within parse.